### PR TITLE
Users can now pass filter function to RecordingTransaction to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# fluo-recipes
+# Fluo Recipes
+
+Common code for Fluo application developers.  Below are the available recipes:
+
+* [RecordingTransaction][recording-tx] - A wrapper for a Fluo transaction that records all transaction
+operations to a log which can be used to export data from Fluo.
+
+[recording-tx]: docs/recording-tx.md

--- a/docs/recording-tx.md
+++ b/docs/recording-tx.md
@@ -1,0 +1,68 @@
+# RecordingTransaction recipe
+
+A `RecordingTransaction` is an implementation of `Transaction` that logs all transaction operations
+(i.e GET, SET, or DELETE) to a `TxLog` object for later uses such as exporting data.  The code below
+shows how a RecordingTransaction is created by wrapping a Transaction object:
+
+```java
+RecordingTransactionBase rtx = RecordingTransactionBase.wrap(tx);
+```
+
+A predicate function can be passed to wrap method to select which log entries to record.  The code
+below only records log entries whose column family is `meta`:
+
+```java
+RecordingTransactionBase rtx = RecordingTransactionBase.wrap(tx,
+                               le -> le.getColumn().getFamily().toString().equals("meta"));
+```
+
+After creating a RecordingTransaction, users can use it as they would use a Transaction object.
+
+```java
+Bytes value = rtx.get(Bytes.of("r1"), new Column("cf1", "cq1"));
+```
+
+While SET or DELETE operations are always recorded to the log, GET operations are only recorded if a
+value was found at the requested row/column.  Also, if a GET method returns an iterator, only the GET
+operations that are retrieved from the iterator are logged.  GET operations are logged as they are
+necessary if you want to determine the changes made by the transaction.
+ 
+When you are done operating on the transaction, you can retrieve the TxLog using the following code:
+
+```java
+TxLog myTxLog = rtx.getTxLog()
+```
+
+Below is example code of how a RecordingTransaction can be used in an observer to record all operations
+performed by the transaction in a TxLog.  In this example, a GET (if data exists) and SET operation
+will be logged.  This TxLog can be added to an export queue and later used to export updates from 
+Fluo.
+
+```java
+public class MyObserver extends AbstractObserver {
+
+    private static final TYPEL = new TypeLayer(new StringEncoder());
+    
+    private ExportQueue<Bytes, TxLog> exportQueue;
+
+    @Override
+    public void process(TransactionBase tx, Bytes row, Column col) {
+
+        // create recording transaction (rtx)
+        RecordingTransactionBase rtx = RecordingTransactionBase.wrap(tx);
+        
+        // use rtx to create a typed transaction & perform operations
+        TypedTransactionBase ttx = TYPEL.wrap(tx);
+        int count = ttx.get().row(row).fam("meta").qual("counter1").toInteger(0);
+        ttx.mutate().row(row).fam("meta").qual("counter1").set(count+1);
+        
+        // when finished performing operations, retrieve transaction log
+        TxLog txLog = rtx.getTxLog()
+
+        // add txLog to exportQueue if not empty
+        if (!txLog.isEmpty()) {
+          exportQueue.add(tx, row, txLog)
+        }
+    }
+}
+```

--- a/modules/core/src/main/java/io/fluo/recipes/transaction/LogEntry.java
+++ b/modules/core/src/main/java/io/fluo/recipes/transaction/LogEntry.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 Fluo authors (see AUTHORS)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.fluo.recipes.transaction;
+
+import com.google.common.base.Preconditions;
+import io.fluo.api.data.Bytes;
+import io.fluo.api.data.Column;
+
+/**
+ * Logs an operation (i.e GET, SET, or DELETE) in a Transaction. Multiple LogEntry objects make up a
+ * {@link TxLog}.
+ */
+public class LogEntry {
+
+  public enum Operation {
+    GET, SET, DELETE
+  }
+
+  private Operation op;
+  private Bytes row;
+  private Column col;
+  private Bytes value;
+
+  private LogEntry() {}
+
+  private LogEntry(Operation op, Bytes row, Column col, Bytes value) {
+    Preconditions.checkNotNull(op);
+    Preconditions.checkNotNull(row);
+    Preconditions.checkNotNull(col);
+    Preconditions.checkNotNull(value);
+    this.op = op;
+    this.row = row;
+    this.col = col;
+    this.value = value;
+  }
+
+  public Operation getOp() {
+    return op;
+  }
+
+  public Bytes getRow() {
+    return row;
+  }
+
+  public Column getColumn() {
+    return col;
+  }
+
+  public Bytes getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof LogEntry) {
+      LogEntry other = (LogEntry) o;
+      return ((op == other.op) && row.equals(other.row) && col.equals(other.col) && value
+          .equals(other.value));
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "LogEntry{op=" + op + ", row=" + row + ", col=" + col + ", value=" + value + "}";
+  }
+
+  public static LogEntry newGet(Bytes row, Column col, Bytes value) {
+    return new LogEntry(Operation.GET, row, col, value);
+  }
+
+  public static LogEntry newSet(Bytes row, Column col, Bytes value) {
+    return new LogEntry(Operation.SET, row, col, value);
+  }
+
+  public static LogEntry newDelete(Bytes row, Column col) {
+    return new LogEntry(Operation.DELETE, row, col, Bytes.EMPTY);
+  }
+}

--- a/modules/core/src/main/java/io/fluo/recipes/transaction/RecordingTransaction.java
+++ b/modules/core/src/main/java/io/fluo/recipes/transaction/RecordingTransaction.java
@@ -14,15 +14,26 @@
 
 package io.fluo.recipes.transaction;
 
+import java.util.function.Predicate;
+
 import io.fluo.api.client.Transaction;
 import io.fluo.api.exceptions.CommitException;
 
+/**
+ * An implementation of {@link Transaction} that logs all transactions operations (GET, SET, or
+ * DELETE) in a {@link TxLog} that can be used for exports
+ */
 public class RecordingTransaction extends RecordingTransactionBase implements Transaction {
 
   private final Transaction tx;
 
   private RecordingTransaction(Transaction tx) {
     super(tx);
+    this.tx = tx;
+  }
+
+  private RecordingTransaction(Transaction tx, Predicate<LogEntry> filter) {
+    super(tx, filter);
     this.tx = tx;
   }
 
@@ -36,7 +47,17 @@ public class RecordingTransaction extends RecordingTransactionBase implements Tr
     tx.close();
   }
 
+  /**
+   * Creates a RecordingTransaction by wrapping an existing Transaction
+   */
   public static RecordingTransaction wrap(Transaction tx) {
     return new RecordingTransaction(tx);
+  }
+
+  /**
+   * Creates a RecordingTransaction using the provided LogEntry filter and existing Transaction
+   */
+  public static RecordingTransaction wrap(Transaction tx, Predicate<LogEntry> filter) {
+    return new RecordingTransaction(tx, filter);
   }
 }

--- a/modules/core/src/main/java/io/fluo/recipes/transaction/RecordingTransactionBase.java
+++ b/modules/core/src/main/java/io/fluo/recipes/transaction/RecordingTransactionBase.java
@@ -14,24 +14,37 @@
 
 package io.fluo.recipes.transaction;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import io.fluo.api.client.TransactionBase;
 import io.fluo.api.config.ScannerConfiguration;
 import io.fluo.api.data.Bytes;
 import io.fluo.api.data.Column;
 import io.fluo.api.exceptions.AlreadySetException;
+import io.fluo.api.iterator.ColumnIterator;
 import io.fluo.api.iterator.RowIterator;
 
+/**
+ * An implementation of {@link TransactionBase} that logs all transactions operations (GET, SET, or
+ * DELETE) in a {@link TxLog} that can be used for exports
+ */
 public class RecordingTransactionBase implements TransactionBase {
 
   private final TransactionBase txb;
-  private TxLog txLog = new TxLog();
+  private final TxLog txLog = new TxLog();
+  private final Predicate<LogEntry> filter;
+
+  RecordingTransactionBase(TransactionBase txb, Predicate<LogEntry> filter) {
+    this.txb = txb;
+    this.filter = filter;
+  }
 
   RecordingTransactionBase(TransactionBase txb) {
-    this.txb = txb;
+    this(txb, le -> true);
   }
 
   @Override
@@ -41,46 +54,123 @@ public class RecordingTransactionBase implements TransactionBase {
 
   @Override
   public void set(Bytes row, Column col, Bytes value) throws AlreadySetException {
-    txLog.addSet(row, col, value);
+    txLog.filteredAdd(LogEntry.newSet(row, col, value), filter);
     txb.set(row, col, value);
   }
 
   @Override
   public void delete(Bytes row, Column col) {
-    txLog.addDelete(row, col);
+    txLog.filteredAdd(LogEntry.newDelete(row, col), filter);
     txb.delete(row, col);
   }
 
+  /**
+   * Logs GETs for returned Row/Columns.  Requests that return no data will not be logged.
+   */
   @Override
   public Bytes get(Bytes row, Column col) {
-    return txb.get(row, col);
+    Bytes val = txb.get(row, col);
+    if (val != null) {
+      txLog.filteredAdd(LogEntry.newGet(row, col, val), filter);
+    }
+    return val;
   }
 
+  /**
+   * Logs GETs for returned Row/Columns.  Requests that return no data will not be logged.
+   */
   @Override
   public Map<Column, Bytes> get(Bytes row, Set<Column> columns) {
-    return txb.get(row, columns);
+    Map<Column, Bytes> colVal = txb.get(row, columns);
+    for (Map.Entry<Column, Bytes> entry : colVal.entrySet()) {
+      txLog.filteredAdd(LogEntry.newGet(row, entry.getKey(), entry.getValue()), filter);
+    }
+    return colVal;
   }
 
+  /**
+   * Logs GETs for returned Row/Columns.  Requests that return no data will not be logged.
+   */
   @Override
   public Map<Bytes, Map<Column, Bytes>> get(Collection<Bytes> rows, Set<Column> columns) {
-    return txb.get(rows, columns);
+    Map<Bytes, Map<Column, Bytes>> rowColVal = txb.get(rows, columns);
+    for (Map.Entry<Bytes, Map<Column, Bytes>> rowEntry : rowColVal.entrySet()) {
+      for (Map.Entry<Column, Bytes> colEntry : rowEntry.getValue().entrySet()) {
+        txLog.filteredAdd(
+            LogEntry.newGet(rowEntry.getKey(), colEntry.getKey(), colEntry.getValue()), filter);
+      }
+    }
+    return rowColVal;
+  }
+
+  /**
+   * Logs GETs for Row/Columns returned by iterators.  Requests that return no data will not be
+   * logged.
+   */
+  @Override
+  public RowIterator get(ScannerConfiguration config) {
+    final RowIterator rowIter = txb.get(config);
+    if (rowIter != null) {
+      return new RowIterator() {
+
+        @Override
+        public boolean hasNext() {
+          return rowIter.hasNext();
+        }
+
+        @Override
+        public Map.Entry<Bytes, ColumnIterator> next() {
+          final Map.Entry<Bytes, ColumnIterator> rowEntry = rowIter.next();
+          if ((rowEntry != null) && (rowEntry.getValue() != null)) {
+            final ColumnIterator colIter = rowEntry.getValue();
+            return
+                new AbstractMap.SimpleEntry<Bytes, ColumnIterator>(
+                    rowEntry.getKey(), new ColumnIterator() {
+
+                  @Override
+                  public boolean hasNext() {
+                    return colIter.hasNext();
+                  }
+
+                  @Override
+                  public Map.Entry<Column, Bytes> next() {
+                    Map.Entry<Column, Bytes> colEntry = colIter.next();
+                    if (colEntry != null) {
+                      txLog.filteredAdd(LogEntry.newGet(rowEntry.getKey(), colEntry.getKey(),
+                                                        colEntry.getValue()), filter);
+                    }
+                    return colEntry;
+                  }
+                });
+          }
+          return rowEntry;
+        }
+      };
+    }
+    return rowIter;
   }
 
   @Override
-  public RowIterator get(ScannerConfiguration config) {
-    return txb.get(config);
+  public long getStartTimestamp() {
+    return txb.getStartTimestamp();
   }
 
   public TxLog getTxLog() {
     return txLog;
   }
 
+  /**
+   * Creates a RecordingTransactionBase by wrapping an existing TransactionBase
+   */
   public static RecordingTransactionBase wrap(TransactionBase txb) {
     return new RecordingTransactionBase(txb);
   }
 
-  @Override
-  public long getStartTimestamp() {
-    return txb.getStartTimestamp();
+  /**
+   * Creates a RecordingTransactionBase using the provided LogEntry filter function and existing
+   * TransactionBase
+   */
+  public static RecordingTransactionBase wrap(TransactionBase txb, Predicate<LogEntry> filter) {
+    return new RecordingTransactionBase(txb, filter);
   }
 }

--- a/modules/core/src/test/java/io/fluo/recipes/transaction/RecordingTransactionTest.java
+++ b/modules/core/src/test/java/io/fluo/recipes/transaction/RecordingTransactionTest.java
@@ -14,13 +14,17 @@
 
 package io.fluo.recipes.transaction;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import io.fluo.api.client.Transaction;
 import io.fluo.api.config.ScannerConfiguration;
 import io.fluo.api.data.Bytes;
 import io.fluo.api.data.Column;
+import io.fluo.api.iterator.ColumnIterator;
+import io.fluo.api.iterator.RowIterator;
 import io.fluo.api.types.StringEncoder;
 import io.fluo.api.types.TypeLayer;
 import io.fluo.api.types.TypedTransaction;
@@ -37,6 +41,7 @@ public class RecordingTransactionTest {
 
   private Transaction tx;
   private RecordingTransaction rtx;
+  private TypeLayer tl = new TypeLayer(new StringEncoder());
 
   @Before
   public void setUp() {
@@ -49,29 +54,51 @@ public class RecordingTransactionTest {
     rtx.set(Bytes.of("r1"), new Column("cf1"), Bytes.of("v1"));
     rtx.set(Bytes.of("r2"), new Column("cf2", "cq2"), Bytes.of("v2"));
     rtx.delete(Bytes.of("r3"), new Column("cf3"));
+    expect(tx.get(Bytes.of("r4"), new Column("cf4"))).andReturn(Bytes.of("v4"));
+    replay(tx);
     rtx.get(Bytes.of("r4"), new Column("cf4"));
 
-    List<TxLog.LogEntry> entries = rtx.getTxLog().getLogEntries();
-    Assert.assertEquals(3, entries.size());
-    Assert.assertEquals("LogEntry{type=SET, row=r1, col=cf1  , value=v1}", entries.get(0)
+    List<LogEntry> entries = rtx.getTxLog().getLogEntries();
+    Assert.assertEquals(4, entries.size());
+    Assert.assertEquals("LogEntry{op=SET, row=r1, col=cf1  , value=v1}", entries.get(0).toString());
+    Assert.assertEquals("LogEntry{op=SET, row=r2, col=cf2 cq2 , value=v2}", entries.get(1)
         .toString());
-    Assert.assertEquals("LogEntry{type=SET, row=r2, col=cf2 cq2 , value=v2}", entries.get(1)
+    Assert
+        .assertEquals("LogEntry{op=DELETE, row=r3, col=cf3  , value=}", entries.get(2).toString());
+    Assert.assertEquals("LogEntry{op=GET, row=r4, col=cf4  , value=v4}", entries.get(3).toString());
+    Assert.assertEquals("{r4 cf4  =v4}", rtx.getTxLog().getOperationMap(LogEntry.Operation.GET)
         .toString());
-    Assert.assertEquals("LogEntry{type=DELETE, row=r3, col=cf3  , value=}", entries.get(2)
+    Assert.assertEquals("{r2 cf2 cq2 =v2, r1 cf1  =v1}",
+        rtx.getTxLog().getOperationMap(LogEntry.Operation.SET).toString());
+    Assert.assertEquals("{r3 cf3  =}", rtx.getTxLog().getOperationMap(LogEntry.Operation.DELETE)
         .toString());
   }
 
   @Test
   public void testTypedTx() {
-    TypeLayer tl = new TypeLayer(new StringEncoder());
     TypedTransaction ttx = tl.wrap(rtx);
     ttx.mutate().row("r5").fam("cf5").qual("cq5").set("1");
     ttx.mutate().row("r6").fam("cf6").qual("cq6").set("1");
-    List<TxLog.LogEntry> entries = rtx.getTxLog().getLogEntries();
+    List<LogEntry> entries = rtx.getTxLog().getLogEntries();
     Assert.assertEquals(2, entries.size());
-    Assert.assertEquals("LogEntry{type=SET, row=r5, col=cf5 cq5 , value=1}", entries.get(0)
+    Assert.assertEquals("LogEntry{op=SET, row=r5, col=cf5 cq5 , value=1}", entries.get(0)
         .toString());
-    Assert.assertEquals("LogEntry{type=SET, row=r6, col=cf6 cq6 , value=1}", entries.get(1)
+    Assert.assertEquals("LogEntry{op=SET, row=r6, col=cf6 cq6 , value=1}", entries.get(1)
+        .toString());
+  }
+
+  @Test
+  public void testFilter() {
+    rtx = RecordingTransaction.wrap(tx, le -> le.getColumn().getFamily().toString().equals("cfa"));
+    TypedTransaction ttx = tl.wrap(rtx);
+    ttx.mutate().row("r1").fam("cfa").qual("cq1").set("1");
+    ttx.mutate().row("r2").fam("cfb").qual("cq2").set("2");
+    ttx.mutate().row("r3").fam("cfa").qual("cq3").set("3");
+    List<LogEntry> entries = rtx.getTxLog().getLogEntries();
+    Assert.assertEquals(2, entries.size());
+    Assert.assertEquals("LogEntry{op=SET, row=r1, col=cfa cq1 , value=1}", entries.get(0)
+        .toString());
+    Assert.assertEquals("LogEntry{op=SET, row=r3, col=cfa cq3 , value=3}", entries.get(1)
         .toString());
   }
 
@@ -125,11 +152,66 @@ public class RecordingTransactionTest {
   }
 
   @Test
-  public void testGetScan() {
+  public void testGetScanNull() {
     ScannerConfiguration scanConfig = new ScannerConfiguration();
     expect(tx.get(scanConfig)).andReturn(null);
     replay(tx);
     Assert.assertNull(rtx.get(scanConfig));
+    verify(tx);
+  }
+
+  @Test
+  public void testGetScanIter() {
+    ScannerConfiguration scanConfig = new ScannerConfiguration();
+    expect(tx.get(scanConfig)).andReturn(new RowIterator() {
+
+      private boolean hasNextRow = true;
+
+      @Override
+      public boolean hasNext() {
+        return hasNextRow;
+      }
+
+      @Override
+      public Map.Entry<Bytes, ColumnIterator> next() {
+        hasNextRow = false;
+        return new AbstractMap.SimpleEntry<>(Bytes.of("r7"), new ColumnIterator(){
+
+          private boolean hasNextCol = true;
+
+          @Override
+          public boolean hasNext() {
+            return hasNextCol;
+          }
+
+          @Override
+          public Map.Entry<Column, Bytes> next() {
+            hasNextCol = false;
+            return new AbstractMap.SimpleEntry<>(new Column("cf7", "cq7"), Bytes.of("v7"));
+          }
+        });
+      }
+    });
+    replay(tx);
+    RowIterator rowIter = rtx.get(scanConfig);
+    Assert.assertNotNull(rowIter);
+    Assert.assertTrue(rtx.getTxLog().isEmpty());
+    Assert.assertTrue(rowIter.hasNext());
+    Map.Entry<Bytes, ColumnIterator> rowEntry = rowIter.next();
+    Assert.assertFalse(rowIter.hasNext());
+    Assert.assertEquals(Bytes.of("r7"), rowEntry.getKey());
+    ColumnIterator colIter = rowEntry.getValue();
+    Assert.assertTrue(colIter.hasNext());
+    Assert.assertTrue(rtx.getTxLog().isEmpty());
+    Map.Entry<Column, Bytes> colEntry = colIter.next();
+    Assert.assertFalse(rtx.getTxLog().isEmpty());
+    Assert.assertFalse(colIter.hasNext());
+    Assert.assertEquals(new Column("cf7", "cq7"), colEntry.getKey());
+    Assert.assertEquals(Bytes.of("v7"), colEntry.getValue());
+    List<LogEntry> entries = rtx.getTxLog().getLogEntries();
+    Assert.assertEquals(1, entries.size());
+    Assert.assertEquals("LogEntry{op=GET, row=r7, col=cf7 cq7 , value=v7}", entries.get(0)
+        .toString());
     verify(tx);
   }
 


### PR DESCRIPTION
logs by entry. RecordingTransaction now logs GET operations. Also,
improved documentation for recipe.